### PR TITLE
Remove unused path_provider_foundation plugin from macOS example

### DIFF
--- a/example/macos/Flutter/GeneratedPluginRegistrant.swift
+++ b/example/macos/Flutter/GeneratedPluginRegistrant.swift
@@ -5,10 +5,8 @@
 import FlutterMacOS
 import Foundation
 
-import path_provider_foundation
 import url_launcher_macos
 
 func RegisterGeneratedPlugins(registry: FlutterPluginRegistry) {
-  PathProviderPlugin.register(with: registry.registrar(forPlugin: "PathProviderPlugin"))
   UrlLauncherPlugin.register(with: registry.registrar(forPlugin: "UrlLauncherPlugin"))
 }


### PR DESCRIPTION
## Regenerate environment variables and update macOS dependencies

**Branched from:** [dev](https://github.com/open-runtime/code_field/tree/dev)
**Branch:** [`chore/nathan-doublechecks`](https://github.com/open-runtime/code_field/tree/chore/nathan-doublechecks)
**PR into:** [dev](https://github.com/open-runtime/code_field/tree/dev)

## Summary

This PR cleans up the `example/` project by removing the `path_provider_foundation` plugin from the macOS platform-specific plugin registration. This improves project hygiene and reduces potential build issues for the macOS example application.

## Changes

- Remove `path_provider_foundation` plugin integration from `example/macos/Flutter/GeneratedPluginRegistrant.swift`.

### Related PRs
- https://github.com/pieces-app/os_server/pull/2591
- https://github.com/open-runtime/native_audio/pull/56
- https://github.com/open-runtime/native_clipboard/pull/57
- https://github.com/open-runtime/native_events/pull/24
- https://github.com/open-runtime/native_vision/pull/72
- https://github.com/open-runtime/runtime_embedded_opencode_engine/pull/5
- https://github.com/pieces-app/pieces_for_x/pull/2065
- https://github.com/pieces-app/pieces_copilot_module/pull/406
- https://github.com/pieces-app/pieces_saved_materials_module/pull/127
- https://github.com/pieces-app/pieces_settings_module/pull/54
- https://github.com/pieces-app/pieces_workstream_activity_module/pull/98
- https://github.com/pieces-app/super_editor/pull/8
- https://github.com/pieces-app/another-flushbar/pull/2
- https://github.com/open-runtime/generated_runtime/pull/431
- https://github.com/open-runtime/native_extensions/pull/18

---
*This PR is part of a cross-repo change. All related PRs are listed above.*